### PR TITLE
Comment Color Brightness

### DIFF
--- a/src/nord-jetbrains-editor.icls
+++ b/src/nord-jetbrains-editor.icls
@@ -152,7 +152,7 @@ References:
     </option>
     <option name="BASH.SHEBANG">
       <value>
-        <option name="FOREGROUND" value="4c566a" />
+        <option name="FOREGROUND" value="616e88" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -293,7 +293,7 @@ References:
     </option>
     <option name="CONSOLE_GRAY_OUTPUT">
       <value>
-        <option name="FOREGROUND" value="4c566a" />
+        <option name="FOREGROUND" value="616e88" />
       </value>
     </option>
     <option name="CONSOLE_GREEN_BRIGHT_OUTPUT">
@@ -497,7 +497,7 @@ References:
     </option>
     <option name="DEFAULT_BLOCK_COMMENT">
       <value>
-        <option name="FOREGROUND" value="4c566a" />
+        <option name="FOREGROUND" value="616e88" />
       </value>
     </option>
     <option name="DEFAULT_BRACES">
@@ -528,7 +528,7 @@ References:
     <option name="DEFAULT_CONSTANT" baseAttributes="DEFAULT_IDENTIFIER" />
     <option name="DEFAULT_DOC_COMMENT">
       <value>
-        <option name="FOREGROUND" value="4c566a" />
+        <option name="FOREGROUND" value="616e88" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT_TAG">
@@ -539,7 +539,7 @@ References:
     </option>
     <option name="DEFAULT_DOC_COMMENT_TAG_VALUE">
       <value>
-        <option name="FOREGROUND" value="4c566a" />
+        <option name="FOREGROUND" value="616e88" />
         <option name="FONT_TYPE" value="1" />
         <option name="EFFECT_TYPE" value="4" />
       </value>
@@ -615,7 +615,7 @@ References:
     </option>
     <option name="DEFAULT_LINE_COMMENT">
       <value>
-        <option name="FOREGROUND" value="4c566a" />
+        <option name="FOREGROUND" value="616e88" />
       </value>
     </option>
     <option name="DEFAULT_LOCAL_VARIABLE">
@@ -784,7 +784,7 @@ References:
     </option>
     <option name="FOLDED_TEXT_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="4c566a" />
+        <option name="FOREGROUND" value="616e88" />
         <option name="BACKGROUND" value="3b4252" />
       </value>
     </option>
@@ -1003,7 +1003,7 @@ References:
     </option>
     <option name="INLINE_PARAMETER_HINT">
       <value>
-        <option name="FOREGROUND" value="4c566a" />
+        <option name="FOREGROUND" value="616e88" />
         <option name="BACKGROUND" value="3b4252" />
       </value>
     </option>
@@ -1180,7 +1180,7 @@ References:
     </option>
     <option name="LOG_EXPIRED_ENTRY">
       <value>
-        <option name="FOREGROUND" value="4c566a" />
+        <option name="FOREGROUND" value="616e88" />
       </value>
     </option>
     <option name="LOG_WARNING_OUTPUT">
@@ -1224,7 +1224,7 @@ References:
     </option>
     <option name="MARKDOWN_BLOCK_QUOTE">
       <value>
-        <option name="FOREGROUND" value="4c566a" />
+        <option name="FOREGROUND" value="616e88" />
       </value>
     </option>
     <option name="MARKDOWN_CODE_BLOCK">
@@ -1617,7 +1617,7 @@ References:
     </option>
     <option name="TDIFF_EXCLUDED_COLUMN">
       <value>
-        <option name="FOREGROUND" value="4c566a" />
+        <option name="FOREGROUND" value="616e88" />
       </value>
     </option>
     <option name="TDIFF_FUZZY_MATCHED">


### PR DESCRIPTION
> Bound to https://github.com/arcticicestudio/nord/issues/94
> Resolves #41 

This issue will implement the increase of the comment color (`nord3`) brightness by 10% from a lightness level of ~35% to ~45%.

➜ Please see https://github.com/arcticicestudio/nord/issues/94 for all details about this design change decision.

#### Before

![gh-146-before](https://user-images.githubusercontent.com/7836623/54902736-76886c80-4eda-11e9-86cd-dfc935aff5e3.png)

![gh-145-before-2](https://user-images.githubusercontent.com/7836623/54902735-76886c80-4eda-11e9-9aa0-41ded647bdb2.png)

#### After

![gh-146-preview](https://user-images.githubusercontent.com/7836623/54902766-856f1f00-4eda-11e9-897a-9b0971586a0b.png)

![gh-145-preview-2](https://user-images.githubusercontent.com/7836623/54902765-856f1f00-4eda-11e9-9d09-50c89faece43.png)
